### PR TITLE
Add version field to webmanifest

### DIFF
--- a/assets/manifest.webmanifest
+++ b/assets/manifest.webmanifest
@@ -2,6 +2,7 @@
   "id": "/",
   "short_name": "Telnet",
   "name": "Telnet",
+  "version": "0.0.1",
   "icons": [
     {
       "src": "images/icons-vector.svg",


### PR DESCRIPTION
Version field was added as a required attribute for IWAs so adding it so that the generated IWA can be run on Chrome.

LMK if you'd prefer some other version number than 0.0.1. Just chose the same one there was on package.json for now.