### PR TITLE
Add `cross-origin-isolated` to Permissions Policy

### DIFF
--- a/assets/manifest.webmanifest
+++ b/assets/manifest.webmanifest
@@ -27,6 +27,7 @@
   "display": "standalone",
   "scope": "/",
   "permissions_policy": {
-    "direct-sockets": [ "self"]
+    "cross-origin-isolated": ["self"],
+    "direct-sockets": ["self"]
   }
 }


### PR DESCRIPTION
We recently landed https://crrev.com/c/4568370, which fixed a bug related to how we treated cross-origin iframes embedded in IWAs. As part of fixing that, we also added missing checks for the `cross-origin-isolated` permissions policy. In the future, we are considering to automatically grant IWAs the `cross-origin-isolated` permissions policy. However, until we get to that point, IWA developers will have to explicitly opt-in in the Web App Manifest.

See https://github.com/WICG/isolated-web-apps/blob/main/Permissions.md for more details.