### PR TITLE
Revert "Import TS types from @types/w3c-direct-sockets"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "xterm-addon-fit": "^0.5.0"
       },
       "devDependencies": {
-        "@types/w3c-direct-sockets": "^0.0.2",
         "@typescript-eslint/eslint-plugin": "^5.25.0",
         "@typescript-eslint/parser": "^5.25.0",
         "clean-webpack-plugin": "^4.0.0",
@@ -442,13 +441,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/w3c-direct-sockets": {
-      "version": "0.0.2",
-      "resolved": "https://us-npm.pkg.dev/artifact-foundry-prod/ah-3p-staging-npm/@types/w3c-direct-sockets/-/w3c-direct-sockets-0.0.2.tgz",
-      "integrity": "sha512-MsoSl3jJGhSG4KeS/isRyyHNbwXRSZzG0Kf38UKvRRrETXaM2S+EnWSVzFlCDQLMcUTmeFzMIUWcWtDX7fXDzA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -6578,12 +6570,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@types/w3c-direct-sockets": {
-      "version": "0.0.2",
-      "resolved": "https://us-npm.pkg.dev/artifact-foundry-prod/ah-3p-staging-npm/@types/w3c-direct-sockets/-/w3c-direct-sockets-0.0.2.tgz",
-      "integrity": "sha512-MsoSl3jJGhSG4KeS/isRyyHNbwXRSZzG0Kf38UKvRRrETXaM2S+EnWSVzFlCDQLMcUTmeFzMIUWcWtDX7fXDzA==",
-      "dev": true
     },
     "@types/ws": {
       "version": "8.18.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "xterm-addon-fit": "^0.5.0"
   },
   "devDependencies": {
-    "@types/w3c-direct-sockets": "^0.0.2",
     "@typescript-eslint/eslint-plugin": "^5.25.0",
     "@typescript-eslint/parser": "^5.25.0",
     "clean-webpack-plugin": "^4.0.0",

--- a/src/direct-sockets.d.ts
+++ b/src/direct-sockets.d.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* https://wicg.github.io/direct-sockets/#dom-tcpsocketoptions */
+interface TCPSocketOptions {
+  sendBufferSize?: number;
+  receiveBufferSize? : number;
+
+  noDelay?: boolean;
+  keepAliveDelay?: number;
+}
+
+/* https://wicg.github.io/direct-sockets/#dom-tcpsocketopeninfo */
+interface TCPSocketOpenInfo {
+  readable: ReadableStream<Uint8Array>;
+  writable: WritableStream<Uint8Array>;
+
+  remoteAddress: string;
+  remotePort: number;
+
+  localAddress: string;
+  localPort: number;
+}
+
+/**
+ * https://wicg.github.io/direct-sockets/#dom-tcpsocket
+ */
+declare class TCPSocket {
+  constructor(remoteAddress: string,
+              remotePort: number,
+              options?: TCPSocketOptions);
+
+  opened: Promise<TCPSocketOpenInfo>;
+  closed: Promise<void>;
+
+  close(): Promise<void>;
+}
+
+/* https://wicg.github.io/direct-sockets/#dom-tcpserversocketoptions */
+interface TCPServerSocketOptions {
+  localPort?: number;
+  backlog?: number;
+
+  ipv6Only?: boolean;
+}
+
+/* https://wicg.github.io/direct-sockets/#dom-tcpserversocketopeninfo */
+interface TCPServerSocketOpenInfo {
+  readable: ReadableStream<TCPSocket>;
+
+  localAddress: string;
+  localPort: number;
+}
+
+/**
+ * https://wicg.github.io/direct-sockets/#dom-tcpserversocket
+ */
+declare class TCPServerSocket {
+  constructor(localAddress: string,
+              options?: TCPServerSocketOptions);
+
+  opened: Promise<TCPServerSocketOpenInfo>;
+  closed: Promise<void>;
+
+  close(): Promise<void>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,6 @@ import {Terminal} from 'xterm';
 import {FitAddon} from 'xterm-addon-fit';
 import 'xterm/css/xterm.css';
 import './style.css';
-import {TCPSocketOpenInfo} from 'w3c-direct-sockets';
 
 let hostInput: HTMLInputElement;
 let portInput: HTMLInputElement;


### PR DESCRIPTION
Reverts GoogleChromeLabs/telnet-client#61 because `package-lock.json` contains invalid package paths.